### PR TITLE
`Pipfile.lock`に`comtypes`を含んでいるかどうかで`setuptools`や`wheel`のバージョンを変更する分岐を追加

### DIFF
--- a/setup_python.py
+++ b/setup_python.py
@@ -84,7 +84,7 @@ def is_in_pipfile_lock(lib_name: str) -> bool:
 
 
 def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
-    """`pipenv`を用いて実行ディレクトリ直下に`.venv`フォルダを作ります。
+    """`pipenv`を用いて実行ディレクトリ直下に`.venv`フォルダを作りPython実行環境を作ります。
 
     Args:
         setuptools_ver (str, optional): 環境作成に用いる`setuptools`のバージョンを指定します。
@@ -113,7 +113,13 @@ def main():
     pip_install('pipenv')
     remove_venv()
     exists_in_cd('Pipfile.lock')
-    create_venv()
+    if is_in_pipfile_lock('comtypes'):
+        # `comtypes`を3系にインストールするために必要なバージョン。詳細は下記参照
+        # https://github.com/enthought/comtypes/issues/180#issuecomment-1009586423
+        setuptools_ver, wheel_ver = '57.0.0', '0.36.2'
+    else:
+        setuptools_ver, wheel_ver = None, None
+    create_venv(setuptools_ver, wheel_ver)
     _conf_exit(0, True)
 
 

--- a/setup_python.py
+++ b/setup_python.py
@@ -93,8 +93,7 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
     """
     print('仮想環境を作成します。')
     os.environ['PIPENV_VENV_IN_PROJECT'] = 'true'
-    # 事前に`.venv`フォルダが必要なため、`pipenv run 任意のコマンド`(今回は`pip list`)を実行
-    _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')
+    _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')  # 事前に`.venv`フォルダが必要なため、`pipenv run 任意のコマンド`(今回は`pip list`)を実行
     if setuptools_ver:
         _change_ver('setuptools', setuptools_ver)
     if wheel_ver:

--- a/setup_python.py
+++ b/setup_python.py
@@ -3,7 +3,6 @@ import os
 import subprocess
 from subprocess import PIPE, STDOUT
 from pathlib import Path
-from typing import Any
 
 
 proc_arg = {
@@ -67,10 +66,10 @@ def exists_in_cd(tgt):
 
 
 def _change_ver(name: str, ver: str) -> None:
-    """`pipenv update/install ...`を使用せず、仮想環境の`pip`を直接使ってライブラリのバージョンを変更します。
+    """仮想環境のpipを直接使ってライブラリのバージョンを変更します。
 
     Note:
-        `Pipfile.lock`で管理できない、環境作成時に用いるセットアップ系ライブラリを指定するための関数。
+        `Pipfile.lock`で管理できない、環境作成時に用いるライブラリのバージョンを指定するための関数。
     """
     print(f'`{name}`のバージョンを{ver}に変更します。')
     _popen('pipenv', 'run', 'python', '-m', 'pip', 'uninstall', '-y', name)

--- a/setup_python.py
+++ b/setup_python.py
@@ -84,7 +84,7 @@ def is_in_pipfile_lock(lib_name: str) -> bool:
 
 
 def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
-    """`pipenv`を用いて実行ディレクトリ直下に`.venv`フォルダを作りPython実行環境を作ります。
+    """`pipenv`を用いて実行ディレクトリ直下に`.venv`フォルダを作りPython仮想環境を作ります。
 
     Args:
         setuptools_ver (str, optional): 環境作成に用いる`setuptools`のバージョンを指定します。
@@ -92,10 +92,9 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
         wheel_ver (str, optional): 環境作成に用いる`wheel`のバージョンを指定します。
             デフォルトではローカル環境にある`pipenv`の仕様に依存したバージョンとなります。
     """
-    _popen('chcp', '65001')
-    print('`.venv`フォルダを作成します。')
+    print('仮想環境を作成します。')
     os.environ['PIPENV_VENV_IN_PROJECT'] = 'true'
-    print('.venv にpython.exeや環境セットアップ系ライブラリをインストールします。')
+    print('`.venv`フォルダを作成して`python.exe`や環境セットアップ系ライブラリをインストールします。')
     # `pipenv sync ...`前に`pipenv run ...`することで、ライブラリ依存関係構築の前に
     # `.venv`フォルダを作成してデフォルトの`pip`, `setuptools`, `wheel`をインストールする
     _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')
@@ -105,10 +104,11 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
         _change_ver('wheel', wheel_ver)
     print('`.venv`フォルダに`Pipfile.lock`で指定されているライブラリをインストールします。')
     _popen('pipenv', 'sync', '--dev')
-    print('`.venv`フォルダの作成が完了しました。')
+    print('仮想環境の作成が完了しました。')
 
 
 def main():
+    _popen('chcp', '65001')  # 文字コードにより`pipenv`が失敗する可能性があるため指定
     print('Python環境のセットアップを行います…\n')
     pip_install('pipenv')
     remove_venv()

--- a/setup_python.py
+++ b/setup_python.py
@@ -93,9 +93,7 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
     """
     print('仮想環境を作成します。')
     os.environ['PIPENV_VENV_IN_PROJECT'] = 'true'
-    print('`.venv`フォルダを作成して`python.exe`や環境セットアップ系ライブラリをインストールします。')
-    # `pipenv sync ...`前に`pipenv run ...`することで、ライブラリ依存関係構築の前に
-    # `.venv`フォルダを作成してデフォルトの`pip`, `setuptools`, `wheel`をインストールする
+    # 事前に`.venv`フォルダが必要なため、`pipenv run 任意のコマンド`(今回は`pip list`)を実行
     _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')
     if setuptools_ver:
         _change_ver('setuptools', setuptools_ver)

--- a/setup_python.py
+++ b/setup_python.py
@@ -93,7 +93,7 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
     """
     print('仮想環境を作成します。')
     os.environ['PIPENV_VENV_IN_PROJECT'] = 'true'
-    _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')  # 事前に`.venv`フォルダが必要なため、`pipenv run 任意のコマンド`(今回は`pip list`)を実行
+    _popen('pipenv', 'run', 'python', '-m', 'pip', 'list')  # 事前に`.venv`フォルダが必要なため、`pipenv run 任意のコマンド`を実行
     if setuptools_ver:
         _change_ver('setuptools', setuptools_ver)
     if wheel_ver:

--- a/setup_python.py
+++ b/setup_python.py
@@ -108,7 +108,7 @@ def create_venv(setuptools_ver: str = None, wheel_ver: str = None) -> None:
 
 
 def main():
-    _popen('chcp', '65001')  # 文字コードにより`pipenv`が失敗する可能性があるため指定
+    _popen('chcp', '65001')  # デフォルト文字コードでは`pipenv`が失敗する可能性があるため指定
     print('Python環境のセットアップを行います…\n')
     pip_install('pipenv')
     remove_venv()


### PR DESCRIPTION
#1 の対応です。

`Pipfile.lock`に`comtypes`を含んでいれば、`setuptools`や`wheel`のバージョンを変更した上で仮想環境が作られるように分岐を作成しました。

- `comtypes`が指定されていない場合にはローカルの`pipenv`の仕様に依存したバージョンが使用されます。

なぜこのバージョンなのかは[`comtypes`issue](https://github.com/enthought/comtypes/issues/180#issuecomment-1009586423)を参照してください。